### PR TITLE
[Fix] #61 인물 리스트 필터링 업데이트 오류 해결

### DIFF
--- a/app/src/main/java/com/example/guessme/ui/view/PeopleListFragment.kt
+++ b/app/src/main/java/com/example/guessme/ui/view/PeopleListFragment.kt
@@ -84,7 +84,7 @@ class PeopleListFragment : BaseFragment<FragmentPeopleListBinding>(R.layout.frag
                     }
                 }
 
-                peopleListAdapter.submitList(filteredList)
+                peopleListAdapter.submitList(filteredList.toMutableList())
             }
 
             override fun afterTextChanged(p0: Editable?) {


### PR DESCRIPTION
### Summary✔️
recyclerview에 새로운 값이 listadapter의 submit를 통해 들어오지만
갱신이 되지 않는 현상 해결

### Result👀
- listAdapter는 참조값이 같으면 내부 데이터 비교하지 않는 것이 원인
- toMutableList를 통해 매번 새로운 참조값을 가지도록 함

궁금한 부분
- 이전에도 매번 새로운 ArrayList를 생성해 참조값이 달라짐. 하지만 업데이트가 일어나지 않음!
-> 이 부분도 가능하다면 멘토링 때 여쭤볼 것!

### Close Issue🔨
closes #61 
